### PR TITLE
Added patch to allow access to 4 Cubie* uarts.

### DIFF
--- a/clone-repos.sh
+++ b/clone-repos.sh
@@ -65,3 +65,10 @@ else
   cd ..
 fi
 
+cd xen
+for i in ../patches/xen*.patch
+do
+  patch -p1 < $i
+done
+cd ..
+

--- a/patches/xen-0000-fix-blacklist-for-cubie-uarts.patch
+++ b/patches/xen-0000-fix-blacklist-for-cubie-uarts.patch
@@ -1,0 +1,22 @@
+diff --git a/xen/arch/arm/platforms/sunxi.c b/xen/arch/arm/platforms/sunxi.c
+index fb12801..dd4505e 100644
+--- a/xen/arch/arm/platforms/sunxi.c
++++ b/xen/arch/arm/platforms/sunxi.c
+@@ -27,10 +27,14 @@ static const char * const sunxi_dt_compat[] __initconst =
+ static const struct dt_device_match sunxi_blacklist_dev[] __initconst =
+ {
+     /*
+-     * The UARTs share a page which runs the risk of mapping the Xen console
+-     * UART to dom0, so don't map any of them.
++     * Four of the UARTs share a page which runs the risk of mapping the Xen console
++     * UART to dom0, black list all devices that share that page. The other
++     * four UARTs will remain available for use.
+      */
+-    DT_MATCH_COMPATIBLE("snps,dw-apb-uart"),
++    DT_MATCH_PATH("/soc@01c00000/serial@01c28000"),
++    DT_MATCH_PATH("/soc@01c00000/serial@01c28400"),
++    DT_MATCH_PATH("/soc@01c00000/serial@01c28800"),
++    DT_MATCH_PATH("/soc@01c00000/serial@01c28c00"),
+     { /* sentinel */ },
+ };
+ 


### PR DESCRIPTION
1. Updated clone-repos.sh to look for xen patches
2. Added cubie\* uart blacklist fix.  Although it is only a different sort of
   workaround.  The real fix will be to have Xen examine the memory regions
   allocated to a domain, and blacklist any device that overlaps with the
   regions Xen is using for itself.
